### PR TITLE
[1.4] Journey Mode Research Added

### DIFF
--- a/PboneUtils/Items/Arena/AsphaltPlatform.cs
+++ b/PboneUtils/Items/Arena/AsphaltPlatform.cs
@@ -1,6 +1,7 @@
 ﻿using PboneUtils.Tiles;
 using Terraria.ID;
 using Terraria.ModLoader;
+using Terraria.GameContent.Creative;
 
 namespace PboneUtils.Items.Arena
 {
@@ -14,6 +15,11 @@ namespace PboneUtils.Items.Arena
             Item.createTile = ModContent.TileType<AsphaltPlatformTile>();
 
             base.SetDefaults();
+        }
+        public override void SetStaticDefaults()
+        {
+            base.SetStaticDefaults();
+            CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 200;
         }
 
         public override void AddRecipes()

--- a/PboneUtils/Items/PboneUtilsItem.cs
+++ b/PboneUtils/Items/PboneUtilsItem.cs
@@ -3,6 +3,7 @@ using Microsoft.Xna.Framework;
 using Terraria;
 using Microsoft.Xna.Framework.Graphics;
 using Terraria.GameContent;
+using Terraria.GameContent.Creative;
 using PboneLib.CustomLoading.Content.Implementations.Content;
 
 namespace PboneUtils.Items
@@ -34,6 +35,11 @@ namespace PboneUtils.Items
                 Item.Size = correctedSize;
             }*/
             Item.Size = new Vector2(24);
+        }
+        public override void SetStaticDefaults()
+        {
+            base.SetStaticDefaults();
+            CreativeItemSacrificesCatalog.Instance.SacrificeCountNeededByItemId[Type] = 1;
         }
 
         public override void HoldItem(Player player)


### PR DESCRIPTION
Super simple PR that adds Journey Mode researching to all of the items. It was even easier because the PboneUtilsItem was already a thing. Everything requires 1 sacrifice except Asphalt Platforms which requires 200.