### PR TITLE
Preview May Update

### DIFF
--- a/PboneUtils/Changelog.txt
+++ b/PboneUtils/Changelog.txt
@@ -1,3 +1,19 @@
+Version 1.2.13 Changes ------------------------------------------------------------------------------------------
+NPCs
+- Added an alternate sprite for the Miner for parties
+- Added Happiness for the Miner
+-- Loves Underground; Likes Forest, Hallow, Demolitionist, Merchant, and Princess; Dislikes Desert, Hates Ocean.
+- Added Happiness quotes for the Miner (and Mysterious Trader)
+- Added gore for the Miner and Mysterious Trader when they die
+- Made the Miner and Mysterious Trader animate in the Bestiary.
+
+Bugs
+- Re-implemented Census support
+
+Version 1.2.12 Changes ------------------------------------------------------------------------------------------
+Items
+- Added Journey Mode Researching for all items
+
 Version 1.2.9 Changes ------------------------------------------------------------------------------------------
 Items
 - Added Building items

--- a/PboneUtils/Items/Bait/BagOfWorms.cs
+++ b/PboneUtils/Items/Bait/BagOfWorms.cs
@@ -18,7 +18,7 @@ namespace PboneUtils.Items.Bait
         }
 
         public override bool ConsumeItem(Player player) => false;
-        public override bool CanBeConsumedAsAmmo(Player player) => false;
+        public override bool CanBeConsumedAsAmmo(Item weapon, Player player) => false;
 
         public override void AddRecipes()
         {

--- a/PboneUtils/Items/Bait/Infiniworm.cs
+++ b/PboneUtils/Items/Bait/Infiniworm.cs
@@ -19,7 +19,7 @@ namespace PboneUtils.Items.Bait
         }
 
         public override bool ConsumeItem(Player player) => false;
-        public override bool CanBeConsumedAsAmmo(Player player) => false;
+        public override bool CanBeConsumedAsAmmo(Item weapon, Player player) => false;
 
         public override void AddRecipes()
         {

--- a/PboneUtils/Items/Liquid/BottomlessHoneyBucket.cs
+++ b/PboneUtils/Items/Liquid/BottomlessHoneyBucket.cs
@@ -31,7 +31,7 @@ namespace PboneUtils.Items.Liquid
                 {
                     if (LiquidHelper.PlaceLiquid(Player.tileTargetX, Player.tileTargetY, LiquidID.Honey))
                     {
-                        SoundEngine.PlaySound(SoundID.Splash, (int)player.position.X, (int)player.position.Y);
+                        SoundEngine.PlaySound(SoundID.Splash, player.position);
                         return true;
                     }
                 }

--- a/PboneUtils/Items/Liquid/SuperSweetSponge.cs
+++ b/PboneUtils/Items/Liquid/SuperSweetSponge.cs
@@ -31,7 +31,7 @@ namespace PboneUtils.Items.Liquid
                 {
                     if (LiquidHelper.DrainLiquid(Player.tileTargetX, Player.tileTargetY, LiquidID.Honey))
                     {
-                        SoundEngine.PlaySound(SoundID.Splash, (int)player.position.X, (int)player.position.Y);
+                        SoundEngine.PlaySound(SoundID.Splash, player.position);
                         return true;
                     }
                 }

--- a/PboneUtils/Items/Storage/PortableStoragePlayer.cs
+++ b/PboneUtils/Items/Storage/PortableStoragePlayer.cs
@@ -39,7 +39,7 @@ namespace PboneUtils.Items.Storage
             int projectileType = ModContent.ProjectileType<T>();
             T instance = new T();
             int bankID = instance.ChestType;
-            LegacySoundStyle useSound = instance.UseSound;
+            SoundStyle useSound = instance.UseSound;
 
             if (Main.projectile[whoAmI].active && Main.projectile[whoAmI].type == projectileType)
             {

--- a/PboneUtils/MiscModPlayers/StarMagnetPlayer.cs
+++ b/PboneUtils/MiscModPlayers/StarMagnetPlayer.cs
@@ -43,7 +43,7 @@ namespace PboneUtils.MiscModPlayers
                     num144 = 12f / num144;
                     num142 *= num144;
                     num143 *= num144;
-                    Projectile.NewProjectile(Entity.GetSource_None(), vector.X, vector.Y, num142, num143, ProjectileID.FallingStar, 1000, 10f, Main.myPlayer);
+                    Projectile.NewProjectile(null, vector.X, vector.Y, num142, num143, ProjectileID.FallingStar, 1000, 10f, Main.myPlayer);
                 }
             }
         }

--- a/PboneUtils/PboneUtils.IL.cs
+++ b/PboneUtils/PboneUtils.IL.cs
@@ -42,7 +42,7 @@ namespace PboneUtils
                     Main.LocalPlayer.GetModPlayer<PortableStoragePlayer>().SafeGargoyleOpen || Main.LocalPlayer.GetModPlayer<PortableStoragePlayer>().DefendersCrystalOpen
                         ))
                     {
-                        SoundEngine.PlaySound(SoundID.Item59, -1, -1);
+                        SoundEngine.PlaySound(SoundID.Item59);
                     }
                 });
             }

--- a/PboneUtils/PboneUtils.cs
+++ b/PboneUtils/PboneUtils.cs
@@ -10,6 +10,7 @@ using PboneUtils.DataStructures.MysteriousTrader;
 using PboneUtils.ID;
 using PboneUtils.Packets;
 using System.IO;
+using Terraria.Localization;
 using Terraria.ModLoader;
 using Terraria.ModLoader.Config;
 
@@ -97,6 +98,16 @@ namespace PboneUtils
             new MysteriousTraderShopManager();
             new CompiledMysteriousTraderShop(MysteriousTraderShopManager.Instance);
 #pragma warning restore CA1806 // Do not ignore method results
+
+            // Temporary Census here until the CensusCompatibility is fixed
+            if (ModLoader.TryGetMod("Census", out Mod censusMod))
+			{
+                if (PboneUtilsConfig.Instance.Miner)
+                    censusMod.Call("TownNPCCondition", ModContent.NPCType<NPCs.Town.Miner>(), Language.GetTextValue("Mods.PboneUtils.Census.Description.Miner"));
+
+                if (PboneUtilsConfig.Instance.MysteriousTrader)
+                    censusMod.Call("TownNPCCondition", ModContent.NPCType<NPCs.Town.MysteriousTrader>(), Language.GetTextValue("Mods.PboneUtils.Census.Description.MysteriousTrader"));
+            }
         }
 
         #region Recipes

--- a/PboneUtils/Projectiles/Selection/LiquidComboPro.cs
+++ b/PboneUtils/Projectiles/Selection/LiquidComboPro.cs
@@ -34,7 +34,7 @@ namespace PboneUtils.Projectiles.Selection
             {
                 if (LiquidHelper.PlaceLiquid(i, j, (byte)LiquidType))
                 {
-                    SoundEngine.PlaySound(SoundID.Splash, (int)Owner.position.X, (int)Owner.position.Y);
+                    SoundEngine.PlaySound(SoundID.Splash, Owner.position);
                     return;
                 }
             }
@@ -42,7 +42,7 @@ namespace PboneUtils.Projectiles.Selection
             {
                 if (LiquidHelper.DrainLiquid(i, j, (byte)LiquidType))
                 {
-                    SoundEngine.PlaySound(SoundID.Splash, (int)Owner.position.X, (int)Owner.position.Y);
+                    SoundEngine.PlaySound(SoundID.Splash, Owner.position);
                     return;
                 }
             }

--- a/PboneUtils/Projectiles/Storage/DefendersCrystalProjectile.cs
+++ b/PboneUtils/Projectiles/Storage/DefendersCrystalProjectile.cs
@@ -16,7 +16,7 @@ namespace PboneUtils.Projectiles.Storage
         public override int ItemType => ModContent.ItemType<DefendersCrystal>();
         public override Texture2D Outline => PboneUtils.Textures["DefendersCrystalOutline"];
         public override bool Animate => false;
-        public override LegacySoundStyle UseSound => SoundID.DD2_BookStaffCast;
+        public override SoundStyle UseSound => SoundID.DD2_BookStaffCast;
 
         public override void SetWhoAmIVariable(PortableStoragePlayer player, int value) => player.DefendersCrystalChest = value;
 

--- a/PboneUtils/Projectiles/Storage/PetrifiedSafeProjectile.cs
+++ b/PboneUtils/Projectiles/Storage/PetrifiedSafeProjectile.cs
@@ -14,7 +14,7 @@ namespace PboneUtils.Projectiles.Storage
         public override int ItemType => ModContent.ItemType<PetrifiedSafe>();
         public override Texture2D Outline => PboneUtils.Textures["PetrifiedSafeOutline"];
         public override bool Animate => false;
-        public override LegacySoundStyle UseSound => SoundID.Item37;
+        public override SoundStyle UseSound => SoundID.Item37;
 
         public override void SetWhoAmIVariable(PortableStoragePlayer player, int value) => player.SafeGargoyleChest = value;
 

--- a/PboneUtils/Projectiles/Storage/StorageProjectile.cs
+++ b/PboneUtils/Projectiles/Storage/StorageProjectile.cs
@@ -15,7 +15,7 @@ namespace PboneUtils.Projectiles.Storage
 
         public abstract void SetWhoAmIVariable(PortableStoragePlayer player, int value);
         public virtual bool Animate => true;
-        public abstract LegacySoundStyle UseSound { get; }
+        public abstract SoundStyle UseSound { get; }
 
         public override void SetStaticDefaults()
         {

--- a/PboneUtils/build.txt
+++ b/PboneUtils/build.txt
@@ -1,6 +1,6 @@
 displayName = pbone's Utilities
 author = pbone
-version = 1.2.12
+version = 1.2.13
 homepage = https://forums.terraria.org/index.php?threads/pbones-utilities.105537/
 buildIgnore = build.txt, bin/*, obj/*, PboneLib/*, Thumbs.db, .*
 modReferences = PboneLib


### PR DESCRIPTION
Fixed the sound related changes and change to `CanBeConsumedAsAmmo()`.
Census support temporarily re-added to `PostSetupContent()`.
`Entity.GetSource_None()` doesn't seem to exist anymore, but I think passing `null` does the same thing.

**Version number incremented**